### PR TITLE
feat: 회원가입/로그인 에러 처리 기능 추가

### DIFF
--- a/src/main/java/io/wisoft/kimbanana/auth/controller/AuthController.java
+++ b/src/main/java/io/wisoft/kimbanana/auth/controller/AuthController.java
@@ -49,7 +49,7 @@ public class AuthController {
     @PostMapping("/sign-in")
     public ResponseEntity<TokenResponse> signIn(@RequestBody SignInRequest request) {
         if(request.getEmail() == null || request.getPassword() == null) {
-            return ResponseEntity.badRequest().build();
+            throw new IllegalArgumentException("이메일과 비밀번호는 필수입니다.");
         }
 
         return ResponseEntity.ok(authService.signIn(request));
@@ -57,10 +57,13 @@ public class AuthController {
 
     @PostMapping("/refresh")
     public ResponseEntity<TokenResponse> refresh(@RequestHeader("Authorization") String header) {
+        if(header == null || !header.startsWith("Bearer ")) {
+            throw new IllegalArgumentException("Authorization 헤더는 필수입니다");
+        }
         String refreshToken = header.replace("Bearer ", "");
 
         if(refreshToken.isEmpty()) {
-            return ResponseEntity.badRequest().build();
+            throw new IllegalArgumentException("리프레시 토큰이 비어있습니다.");
         }
 
         return ResponseEntity.ok(authService.refresh(refreshToken));

--- a/src/main/java/io/wisoft/kimbanana/auth/exception/AuthExceptionHandler.java
+++ b/src/main/java/io/wisoft/kimbanana/auth/exception/AuthExceptionHandler.java
@@ -1,0 +1,22 @@
+package io.wisoft.kimbanana.auth.exception;
+
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class AuthExceptionHandler {
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<Map<String, String>> handleSignUpException(IllegalStateException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("SIGN_UP_FAILED", e.getMessage()));
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<Map<String, String>> handleAuthenticationFailed(AuthenticationException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("Authentication_ERROR", e.getMessage()));
+    }
+}

--- a/src/main/java/io/wisoft/kimbanana/auth/repository/JdbcUserRepository.java
+++ b/src/main/java/io/wisoft/kimbanana/auth/repository/JdbcUserRepository.java
@@ -1,5 +1,6 @@
 package io.wisoft.kimbanana.auth.repository;
 
+import io.swagger.v3.oas.models.security.SecurityScheme.In;
 import io.wisoft.kimbanana.auth.User;
 import java.util.Optional;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -34,8 +35,8 @@ public class JdbcUserRepository implements UserRepository {
     }
 
     @Override
-    public void save(final User user) {
+    public Integer save(final User user) {
         String sql = "INSERT INTO users (email, name, password) VALUES (?, ?, ?)";
-        jdbcTemplate.update(sql, user.getEmail(), user.getName(), user.getPassword());
+        return jdbcTemplate.update(sql, user.getEmail(), user.getName(), user.getPassword());
     }
 }

--- a/src/main/java/io/wisoft/kimbanana/auth/repository/UserRepository.java
+++ b/src/main/java/io/wisoft/kimbanana/auth/repository/UserRepository.java
@@ -5,5 +5,5 @@ import java.util.Optional;
 
 public interface UserRepository {
     Optional<User> findByEmail(String email);
-    void save(User user);
+    Integer save(User user);
 }

--- a/src/main/java/io/wisoft/kimbanana/auth/service/AuthService.java
+++ b/src/main/java/io/wisoft/kimbanana/auth/service/AuthService.java
@@ -7,6 +7,7 @@ import io.wisoft.kimbanana.auth.dto.TokenResponse;
 import io.wisoft.kimbanana.auth.jwt.JwtTokenProvider;
 import io.wisoft.kimbanana.auth.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -19,9 +20,9 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
 
 
-    public void signUp(SignUpRequest request) {
+    public Integer signUp(SignUpRequest request) {
         if (userRepository.findByEmail(request.getEmail()).isPresent()) {
-            throw new IllegalArgumentException("이미 가입된 이메일입니다.");
+            throw new IllegalStateException("이미 가입된 이메일입니다.");
         }
 
         User user = User.builder()
@@ -30,7 +31,7 @@ public class AuthService {
                 .password(encoder.encode(request.getPassword()))
                 .build();
 
-        userRepository.save(user);
+        return userRepository.save(user);
     }
 
 
@@ -39,7 +40,7 @@ public class AuthService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일"));
 
         if (!encoder.matches(request.getPassword(), user.getPassword())) {
-            throw new IllegalArgumentException("비밀번호 불일치");
+            throw new BadCredentialsException("비밀번호 불일치");
         }
         String accessToken = jwtTokenProvider.generateAccessToken(user.getEmail());
         String refreshToken = jwtTokenProvider.generateRefreshToken(user.getEmail());
@@ -49,7 +50,7 @@ public class AuthService {
 
     public TokenResponse refresh(String refreshToken) {
         if (!jwtTokenProvider.validateToken(refreshToken)) {
-            throw new IllegalArgumentException("Refresh 토큰이 유효하지 않음");
+            throw new BadCredentialsException("Refresh 토큰이 유효하지 않음");
         }
 
         String email = jwtTokenProvider.getEmail(refreshToken);

--- a/src/main/java/io/wisoft/kimbanana/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/wisoft/kimbanana/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package io.wisoft.kimbanana.common.exception;
+
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String , String>> handleInvalidRequest(IllegalArgumentException e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("INVALID_INPUT", e.getMessage()));
+    }
+
+}


### PR DESCRIPTION
- 이메일 중복 시 409 Conflict 예외 반환
- 비밀번호 불일치 시 401 Unauthorized 예외 반환
- 잘못된 입력값(이메일·비밀번호) 400 Bad Request 예외 반환
- @RestControllerAdvice 기반 전역 예외 처리기 적용